### PR TITLE
Fix docs links

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -59,7 +59,7 @@ test:
     - cd docs && jupytext --execute tutorials/tutorial_3k_tcr.md
 
 about:
-  home: https://scverse.github.io/scirpy
+  home: https://scverse.org/scirpy
   dev_url: https://github.com/scverse/scirpy
   license: BSD-3
   license_family: BSD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing
 
 We welcome contributions to Scirpy! Please have a look at the [developer
-docs](https://scverse.github.io/scirpy/develop/developer_docs.html) for
+docs](https://scverse.org/scirpy/develop/developer_docs.html) for
 useful information around making a pull-request.

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Scirpy: A Scanpy extension for analyzing single-cell immune-cell receptor sequen
     :alt: Build Status
 
 .. |docs| image::  https://github.com/scverse/scirpy/workflows/docs/badge.svg
-    :target: https://scverse.github.io/scirpy/latest
+    :target: https://scverse.org/scirpy/latest
     :alt: Documentation Status
 
 .. |pypi| image:: https://img.shields.io/pypi/v/scirpy?logo=PyPI
@@ -37,16 +37,16 @@ provides various modules for data import, analysis and visualization.
 
 Getting started
 ^^^^^^^^^^^^^^^
-Please refer to the `documentation <https://scverse.github.io/scirpy/latest>`_. In particular, the
+Please refer to the `documentation <https://scverse.org/scirpy/latest>`_. In particular, the
 
-- `Tutorial <https://scverse.github.io/scirpy/latest/tutorials/tutorial_3k_tcr.html>`_, and the
-- `API documentation <https://scverse.github.io/scirpy/latest/api.html>`_.
+- `Tutorial <https://scverse.org/scirpy/latest/tutorials/tutorial_3k_tcr.html>`_, and the
+- `API documentation <https://scverse.org/scirpy/latest/api.html>`_.
 
-In the documentation, you can also learn more about our `immune-cell receptor model <https://scverse.github.io/scirpy/latest/ir-biology.html>`_.
+In the documentation, you can also learn more about our `immune-cell receptor model <https://scverse.org/scirpy/latest/ir-biology.html>`_.
 
 Case-study
 ~~~~~~~~~~
-The case study from our preprint is available `here <https://scverse.github.io/scirpy-paper/wu2020.html>`_.
+The case study from our preprint is available `here <https://scverse.org/scirpy-paper/wu2020.html>`_.
 
 Installation
 ^^^^^^^^^^^^

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -7,14 +7,14 @@ There are other versions of the documentation available:
 .. raw:: html
 
    <ul id="versions_container">
-	<li><a href="https://scverse.github.io/scirpy">latest release</a></li>
-	<li><a href="https://scverse.github.io/scirpy/develop">latest development version</a></li>
+	<li><a href="https://scverse.org/scirpy">latest release</a></li>
+	<li><a href="https://scverse.org/scirpy/develop">latest development version</a></li>
    </ul>
    <script type="text/javascript">
-   	fetch("https://scverse.github.io/scirpy/versions/versions.json")
+   	fetch("https://scverse.org/scirpy/versions/versions.json")
 	   .then(response => response.json())
 	   .then(versions => versions.forEach((x, i) => {
-	   	document.getElementById("versions_container").innerHTML += '<li><a href="https://scverse.github.io/scirpy/tags/' + x + '/">' + x + '</a></li>\n'
+	   	document.getElementById("versions_container").innerHTML += '<li><a href="https://scverse.org/scirpy/tags/' + x + '/">' + x + '</a></li>\n'
            })).catch((error) => {
 	       document.getElementById("versions_container").innerHTML = "Could not download version information..."
 	   })

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ doc = [
 ]
 
 [tool.flit.metadata.urls]
-Documentation = 'https://scverse.github.io/scirpy/'
+Documentation = 'https://scverse.org/scirpy/'
 
 [tool.pytest.ini_options]
 markers = [


### PR DESCRIPTION
- Scverse rebranding
- Update black version
- pin sphinx version
- Fix autodoc-typehints
- matplotlib intersphinx
- Undo accidental markdown autoformat
- Temporarily ignore sphinx warnings
- Replace scverse.github.io with scverse.org
