### PR TITLE
Add tests for databases and fix IEDB

### DIFF
--- a/scirpy/tests/test_datasets.py
+++ b/scirpy/tests/test_datasets.py
@@ -1,0 +1,11 @@
+import scirpy as ir
+
+
+def test_vdjdb():
+    adata = ir.datasets.vdjdb()
+    assert len(adata.obsm["airr"]) > 1000
+
+
+def test_iedb():
+    adata = ir.datasets.iedb()
+    assert len(adata.obsm["airr"]) > 1000


### PR DESCRIPTION
Despite sticking to v3 version number, IEDB have updated their file format

 * BCR and TCR are now in separate files
 * the csv header has changed. Names are different, and there are now *two* rows
   representing the header.

Close #389 
