### PR TITLE
dependencies: change python-igraph to igraph

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     'scikit-learn',
     'python-levenshtein',
     # 0.10.0 and 0.10.1 have the bug described in https://github.com/igraph/python-igraph/issues/570
-    'python-igraph != 0.10.0,!=0.10.1',
+    'igraph != 0.10.0,!=0.10.1',
     'networkx>=2.5',
     'squarify',
     'airr>=1.2',


### PR DESCRIPTION
Please see https://github.com/igraph/python-igraph/issues/699 for the explanation.