### PR TITLE
Speed up hamming distance calculation and add normalized hamming distance

### DIFF
--- a/src/scirpy/ir_dist/__init__.py
+++ b/src/scirpy/ir_dist/__init__.py
@@ -93,7 +93,9 @@ def _get_distance_calculator(metric: MetricType, cutoff: Union[int, None], *, n_
     elif metric == "levenshtein":
         dist_calc = metrics.LevenshteinDistanceCalculator(cutoff=cutoff, n_jobs=n_jobs, **kwargs)
     elif metric == "hamming":
-        dist_calc = metrics.HammingDistanceCalculator(cutoff=cutoff, n_jobs=n_jobs, **kwargs)
+        dist_calc = metrics.HammingDistanceCalculator(normalize=False, cutoff=cutoff)
+    elif metric == "normalized_hamming":
+        dist_calc = metrics.HammingDistanceCalculator(normalize=True, cutoff=cutoff)
     else:
         raise ValueError("Invalid distance metric.")
 


### PR DESCRIPTION
Close #256 

Faster implementation of hamming distance calculation added to HammingDistanceCalculator. Boolean parameter normalize added to HammingDistanceCalculator constructor. If normalize is set to true, the hamming distance values are divided by the sequence length. New metric normalized_hamming added, which uses the HammingDistanceCalculator with normalize set to true.
