### PR TITLE
add sequence read in for 10x json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning][].
 ### Fixes
 
 - Ensure that clonotype network plots don't have any axis ticks ([#607](https://github.com/scverse/scirpy/pull/607)).
+- Load `sequence`, `sequence_aa` and `sequence_id` fields when reading from 10x JSON format ([#619](https://github.com/scverse/scirpy/pull/619)).
 
 ### Chore
 

--- a/src/scirpy/io/_io.py
+++ b/src/scirpy/io/_io.py
@@ -130,6 +130,9 @@ def _read_10x_vdj_json(
         chain["productive"] = contig["productive"]
         chain["is_cell"] = contig["is_cell"]
         chain["high_confidence"] = contig["high_confidence"]
+        chain["sequence"] = contig["sequence"]
+        chain["aa_sequence"] = contig["aa_sequence"]
+        chain["sequence_id"] = contig["contig_name"]
 
         # additional cols from CR6 outputs: fwr{1,2,3,4}{,_nt} and cdr{1,2}{,_nt}
         fwrs = [f"fwr{i}" for i in range(1, 5)]

--- a/src/scirpy/io/_io.py
+++ b/src/scirpy/io/_io.py
@@ -131,7 +131,7 @@ def _read_10x_vdj_json(
         chain["is_cell"] = contig["is_cell"]
         chain["high_confidence"] = contig["high_confidence"]
         chain["sequence"] = contig["sequence"]
-        chain["aa_sequence"] = contig["aa_sequence"]
+        chain["sequence_aa"] = contig["aa_sequence"]
         chain["sequence_id"] = contig["contig_name"]
 
         # additional cols from CR6 outputs: fwr{1,2,3,4}{,_nt} and cdr{1,2}{,_nt}


### PR DESCRIPTION
Previously, full nt or aa tcr sequences from 10x contigs are not being read in by `read_10x_vdj`. This PR adds those attributes when read from 10x json output.