### PR TITLE
Filter unused categories from clonotype network legend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning][].
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Fixes
+
+ - Filter unused categories from clonotype network legend ([#680](https://github.com/scverse/scirpy/pull/680/)).
+
 ## v0.23.0
 
 ### Changes

--- a/src/scirpy/pl/_clonotypes.py
+++ b/src/scirpy/pl/_clonotypes.py
@@ -617,9 +617,14 @@ def _plot_clonotype_network_panel(
                 **text_kwds,
             )
 
-    # add legend for categorical colors
+    # add legend for categorical colors, showing only categories present in the plot
     if cat_colors is not None and show_legend:
-        for cat, color in cat_colors.items():
+        used_colors = set()
+        if pie_colors is not None:
+            for pc in pie_colors:
+                used_colors.update(pc.keys())
+        visible_cat_colors = {cat: c for cat, c in cat_colors.items() if c in used_colors} if used_colors else cat_colors
+        for cat, color in visible_cat_colors.items():
             # use empty scatter to set labels
             legend_ax.scatter([], [], c=color, label=cat)
         legend_ax.legend(
@@ -627,7 +632,7 @@ def _plot_clonotype_network_panel(
             loc="center left",
             # bbox_to_anchor=(1, 0.5),
             fontsize=legend_fontsize,
-            ncol=(1 if len(cat_colors) <= 14 else 2 if len(cat_colors) <= 30 else 3),
+            ncol=(1 if len(visible_cat_colors) <= 14 else 2 if len(visible_cat_colors) <= 30 else 3),
         )
         legend_ax.axis("off")
 

--- a/src/scirpy/pl/_clonotypes.py
+++ b/src/scirpy/pl/_clonotypes.py
@@ -623,7 +623,9 @@ def _plot_clonotype_network_panel(
         if pie_colors is not None:
             for pc in pie_colors:
                 used_colors.update(pc.keys())
-        visible_cat_colors = {cat: c for cat, c in cat_colors.items() if c in used_colors} if used_colors else cat_colors
+        visible_cat_colors = (
+            {cat: c for cat, c in cat_colors.items() if c in used_colors} if used_colors else cat_colors
+        )
         for cat, color in visible_cat_colors.items():
             # use empty scatter to set labels
             legend_ax.scatter([], [], c=color, label=cat)

--- a/src/scirpy/tests/test_plotting.py
+++ b/src/scirpy/tests/test_plotting.py
@@ -169,8 +169,6 @@ def test_clonotype_network_pie_legend_filters_unused(adata_clonotype_network):
 
     Regression test for https://github.com/scverse/scirpy/issues/679
     """
-    import numpy as np
-
     adata = adata_clonotype_network
     # Add an extra category that no cell in the network has, to ensure
     # the legend filters it out.

--- a/src/scirpy/tests/test_plotting.py
+++ b/src/scirpy/tests/test_plotting.py
@@ -164,6 +164,38 @@ def test_clonotype_network_pie(
 
 
 @pytest.mark.extra
+def test_clonotype_network_pie_legend_filters_unused(adata_clonotype_network):
+    """Legend should only contain categories present in the plotted network.
+
+    Regression test for https://github.com/scverse/scirpy/issues/679
+    """
+    import numpy as np
+
+    adata = adata_clonotype_network
+    # Add an extra category that no cell in the network has, to ensure
+    # the legend filters it out.
+    obs_col = "receptor_type"
+    tmp_ad = adata.mod["airr"] if isinstance(adata, MuData) else adata
+    tmp_ad.obs[obs_col] = tmp_ad.obs[obs_col].cat.add_categories("extra_unused")
+
+    fig = plt.gcf()
+    fig.clear()
+    p = pl.clonotype_network(adata, color=obs_col, show_legend=True)
+    assert isinstance(p, plt.Axes)
+
+    # Collect legend labels from all axes in the figure
+    legend_labels = []
+    for ax in fig.get_axes():
+        legend = ax.get_legend()
+        if legend is not None:
+            legend_labels.extend([t.get_text() for t in legend.get_texts()])
+
+    assert "extra_unused" not in legend_labels, (
+        f"Legend should not contain unused category 'extra_unused', got: {legend_labels}"
+    )
+
+
+@pytest.mark.extra
 def test_logoplot(adata_cdr3):
     p = pl.logoplot_cdr3_motif(adata_cdr3, chains="VJ_1")
     assert isinstance(p, logomaker.Logo)


### PR DESCRIPTION
## Summary
- The clonotype network plot legend now only shows categories that are actually present in the plotted data
- Previously, all categories from the full dataset were listed, making it hard to identify colors when only a subset of categories appeared in the network
- Collects which category colors are used in the pie chart rendering, then filters the legend entries accordingly

Closes #321

## Test plan
- [ ] Verify legend only shows categories present in the plotted network subset
- [ ] Legend still works correctly when all categories are present
- [ ] No visual regression for non-categorical coloring (continuous variables, uniform color)