### PR TITLE
drop distance_key from ir.tl.define_clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@ and this project adheres to [Semantic Versioning][].
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
-## v0.23.1
+## [Unreleased]
 
 ### Fixes
 
  - Filter unused categories from clonotype network legend ([#680](https://github.com/scverse/scirpy/pull/680/)).
  - Fix overflow error that occured in `ir.pp.ir_dist` with sequences longer than 127 characters ([#683](https://github.com/scverse/scirpy/pull/680))
+ - Remove `distance_key` parameter from `define_clonotypes` and raise warning if it is passed via `kwargs` ([#688](https://github.com/scverse/scirpy/pull/688))
 
 ## v0.23.0
 

--- a/src/scirpy/tl/_clonotypes.py
+++ b/src/scirpy/tl/_clonotypes.py
@@ -405,8 +405,10 @@ def define_clonotypes(
         logging.info("ir_dist for sequence='nt' and metric='identity' not found. Computing with default parameters.")  # type: ignore
         ir_dist(params, metric="identity", sequence="nt", key_added="ir_dist_nt_identity")
     if "distance_key" in kwargs:
-        logging.warn("distance_key has been overwritten by \"ir_dist_nt_identity\". For custom distance_key options call define_clonotype_clusters directly.")
-        kwargs = {k: v for k, v in kwargs if k!="distance_key"}
+        logging.warn(
+            'distance_key has been overwritten by "ir_dist_nt_identity". For custom distance_key options call define_clonotype_clusters directly.'
+        )
+        kwargs = {k: v for k, v in kwargs if k != "distance_key"}
     return define_clonotype_clusters(
         params,
         key_added=key_added,

--- a/src/scirpy/tl/_clonotypes.py
+++ b/src/scirpy/tl/_clonotypes.py
@@ -361,7 +361,6 @@ def define_clonotypes(
     adata: DataHandler.TYPE,
     *,
     key_added: str = "clone_id",
-    distance_key: str | None = None,
     airr_mod="airr",
     airr_key="airr",
     chain_idx_key="chain_indices",
@@ -399,16 +398,19 @@ def define_clonotypes(
 
     """
     params = DataHandler(adata, airr_mod, airr_key, chain_idx_key)
-    if distance_key is None and "ir_dist_nt_identity" not in params.adata.uns:
+    if "ir_dist_nt_identity" not in params.adata.uns:
         # For the case of "clonotypes" we want to compute the distance automatically
         # if it doesn't exist yet. Since it's just a sparse ID matrix, this
         # should be instant.
         logging.info("ir_dist for sequence='nt' and metric='identity' not found. Computing with default parameters.")  # type: ignore
-        ir_dist(params, metric="identity", sequence="nt", key_added=distance_key)
-
+        ir_dist(params, metric="identity", sequence="nt", key_added="ir_dist_nt_identity")
+    if "distance_key" in kwargs:
+        logging.warn("distance_key has been overwritten by \"ir_dist_nt_identity\". For custom distance_key options call define_clonotype_clusters directly.")
+        kwargs = {k: v for k, v in kwargs if k!="distance_key"}
     return define_clonotype_clusters(
         params,
         key_added=key_added,
+        distance_key="ir_dist_nt_identity",
         sequence="nt",
         metric="identity",
         partitions="connected",


### PR DESCRIPTION
- drop distance_key from input parameters
- drop distance_key from clause to potentially rerun ir.pp.ir_dist
- add unsilensing via logging warn for distance_key replacement.
- drop distance_key from kwargs if present
- pass distance key explicitly

Closes #687

- [ ] CHANGELOG.md updated
- [ ] Tests added (For bug fixes or new features)
- [ ] Tutorial updated (if necessary)
