### PR TITLE
Speed up identity distance metric computation for two  different sequence arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning][].
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## Unreleased
+
+### Performance improvements
+
+  - Speed up identity distance metric computation for comparisons between two different sequence arrays.
+
 ## v0.24.0
 
 ### Additions

--- a/src/scirpy/ir_dist/metrics.py
+++ b/src/scirpy/ir_dist/metrics.py
@@ -282,18 +282,19 @@ class IdentityDistanceCalculator(DistanceCalculator):
             # In this case, the offsetted distance matrix is the identity matrix
             return scipy.sparse.identity(len(seqs), dtype=self.DTYPE, format="csr")
         else:
-            # actually compare the values
-            def coord_generator():
-                for (i1, s1), (i2, s2) in itertools.product(enumerate(seqs), enumerate(seqs2)):
-                    if s1 == s2:
-                        yield 1, i1, i2
+            cols_by_seq = {}
+            for i2, s2 in enumerate(seqs2):
+                cols_by_seq.setdefault(s2, []).append(i2)
 
-            try:
-                d, row, col = zip(*coord_generator(), strict=False)
-            except ValueError:
-                # happens when there is no match at all
-                d, row, col = (), (), ()
+            row = []
+            col = []
+            for i1, s1 in enumerate(seqs):
+                matching_cols = cols_by_seq.get(s1)
+                if matching_cols is not None:
+                    row.extend([i1] * len(matching_cols))
+                    col.extend(matching_cols)
 
+            d = np.ones(len(row), dtype=self.DTYPE)
             return coo_matrix((d, (row, col)), dtype=self.DTYPE, shape=(len(seqs), len(seqs2))).tocsr()
 
 


### PR DESCRIPTION
## Summary

This PR speeds up the identity distance metric computation when comparing _two different_ sequence arrays via the `IdentityDistanceCalculator`.

Instead of checking every pairwise combination of `seqs` and `seqs2`, the implementation now builds a lookup from sequences in `seqs2` to their column indices and uses it to get matching matrix entries directly.

For example, the previous performance issue became a problem when running the following call with a large number of cells:
```python
ir.pp.ir_dist(mdata, vdjdb, metric="identity", sequence="aa")
```

With this change, I was able to run the `IdentityDistanceCalculator` with millions of sequences in seconds.