### PR TITLE
Use scverse-misc for deprecations

### DIFF
--- a/.conda/recipe.yaml
+++ b/.conda/recipe.yaml
@@ -36,6 +36,7 @@ requirements:
     - scanpy >=1.9.3
     - scikit-learn
     - scipy
+    - scverse-misc >=0.1.3
     - squarify
     - tqdm >=4.63
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning][].
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## Unreleased
+
+### Chore
+
+ - Use the deprecation decorators from [scverse-misc](https://scverse-misc.readthedocs.io/) for deprecated functions
+   and function arguments. `scverse-misc` is now a hard dependency. Deprecated arguments that previously did not
+   emit any warning (`include_fields` and `use_umi_count_col` of the `io.read_*` functions, `cached` and `cache_path`
+   of `datasets.vdjdb` and `datasets.iedb`) now consistently raise a `FutureWarning`, and the API documentation
+   states in which version a function or argument was deprecated ([#704](https://github.com/scverse/scirpy/issues/704)).
+   The undocumented `scirpy.util.deprecated` decorator has been removed in favor of `scverse_misc.deprecated`.
+
 ## v0.25.0
 
 ### Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
   "scanpy>=1.9.3",
   "scikit-learn",
   "scipy",
+  "scverse-misc>=0.1.3",
   "squarify",
   "tqdm>=4.63",                           # https://github.com/tqdm/tqdm/issues/1082
 ]
@@ -75,7 +76,7 @@ doc = [
   "nbconvert",
   "pycairo",
   "scirpy[dandelion]",
-  "scverse-misc[sphinx]>=0.1.2",
+  "scverse-misc[sphinx]>=0.1.3",
   "sphinx>=8.1",
   "sphinx-autodoc-typehints",
   "sphinx-book-theme>=1",

--- a/src/scirpy/datasets/__init__.py
+++ b/src/scirpy/datasets/__init__.py
@@ -4,7 +4,6 @@ import os
 import os.path
 import tempfile
 import urllib.request
-import warnings
 import zipfile
 from datetime import datetime
 from importlib.metadata import version
@@ -21,6 +20,7 @@ import scanpy as sc
 from anndata import AnnData
 from mudata import MuData
 from scanpy import logging
+from scverse_misc import Deprecation, deprecated_arg
 
 from scirpy.io._convert_anndata import from_airr_cells
 from scirpy.io._datastructures import AirrCell
@@ -30,6 +30,9 @@ from scirpy.util import _doc_params, _read_to_str, tqdm
 
 HERE = Path(__file__).parent
 DATASET_ENV_VAR = "SCIRPY_DATA_DIR"
+
+#: Deprecation of the `cached`/`cache_path` arguments, shared by all dataset functions that used to support them.
+_deprecation_caching = Deprecation("0.24.0", "Has no effect. Caching is now handled through `pooch`.")
 
 _AWS_EXAMPLEDATA = pooch.create(
     path=pooch.os_cache("scirpy"),
@@ -137,6 +140,8 @@ def iggytop(*, deduplicated: bool = True, tag: str = "latest") -> AnnData:
 
 
 @_doc_params(pooch_info=_POOCH_INFO)
+@deprecated_arg("cached", _deprecation_caching)
+@deprecated_arg("cache_path", _deprecation_caching)
 def vdjdb(cached: bool | None = None, *, cache_path: None = None, tag: str = "latest") -> AnnData:
     """\
     Download VDJdb through `IggyTop <https://iggytop.readthedocs.io/en/latest/>`_.
@@ -151,9 +156,9 @@ def vdjdb(cached: bool | None = None, *, cache_path: None = None, tag: str = "la
     Parameters
     ----------
     cached
-        Deprecated as of v0.24. Has no effect. Caching is handled through `pooch` now.
+        Has no effect. Caching is handled through `pooch` now.
     cache_path
-        Deprecated as of v0.24. Has no effect.
+        Has no effect. Caching is handled through `pooch` now.
     tag
         The IggyTop release tag to use. Defaults to ``"latest"``, which always fetches
         the most recent release. For reproducibility, pin a specific release tag
@@ -165,12 +170,6 @@ def vdjdb(cached: bool | None = None, *, cache_path: None = None, tag: str = "la
     Each entry is represented as if it was a cell, but without gene expression.
     Metadata is stored in `adata.uns["DB"]`.
     """
-    if cached is not None or cache_path is not None:
-        warnings.warn(
-            "The arguments `cached` and `cache_path` are deprecated since v0.24 and have no effect."
-            "Caching is now handled through Pooch.",
-            category=FutureWarning,
-        )
     adata = iggytop(deduplicated=False, tag=tag)
     adata = adata[adata.obs["source"] == "VDJDB"].copy()
     adata.uns["DB"]["name"] = "VDJDB"
@@ -179,6 +178,8 @@ def vdjdb(cached: bool | None = None, *, cache_path: None = None, tag: str = "la
 
 
 @_doc_params(pooch_info=_POOCH_INFO)
+@deprecated_arg("cached", _deprecation_caching)
+@deprecated_arg("cache_path", _deprecation_caching)
 def iedb(cached: bool | None = None, *, cache_path=None, tag: str = "latest") -> AnnData:
     """\
     Download IEDB through `IggyTop <https://iggytop.readthedocs.io/en/latest/>`_.
@@ -193,9 +194,9 @@ def iedb(cached: bool | None = None, *, cache_path=None, tag: str = "latest") ->
     Parameters
     ----------
     cached
-        Deprecated as of v0.24. Has no effect.
+        Has no effect. Caching is handled through `pooch` now.
     cache_path
-        Deprecated as of v0.24. Has no effect.
+        Has no effect. Caching is handled through `pooch` now.
     tag
         The IggyTop release tag to use. Defaults to ``"latest"``, which always fetches
         the most recent release. For reproducibility, pin a specific release tag
@@ -207,12 +208,6 @@ def iedb(cached: bool | None = None, *, cache_path=None, tag: str = "latest") ->
     Each entry is represented as if it was a cell, but without gene expression.
     Metadata is stored in `adata.uns["DB"]`.
     """
-    if cached is not None or cache_path is not None:
-        warnings.warn(
-            "The arguments `cached` and `cache_path` are deprecated since v0.24 and have no effect."
-            "Caching is now handled through Pooch.",
-            category=FutureWarning,
-        )
     adata = iggytop(deduplicated=False, tag=tag)
     adata = adata[adata.obs["source"] == "IEDB"].copy()
     adata.uns["DB"]["name"] = "IEDB"

--- a/src/scirpy/io/_io.py
+++ b/src/scirpy/io/_io.py
@@ -11,6 +11,7 @@ from typing import Any
 import numpy as np
 import pandas as pd
 from anndata import AnnData
+from scverse_misc import Deprecation, deprecated_arg
 
 from scirpy.util import DataHandler, _doc_params, _is_na2, _is_true, _is_true2, _translate_dna_to_protein
 
@@ -24,6 +25,9 @@ from ._util import _IOLogger, _read_airr_rearrangement_df, doc_airr_fields, doc_
 sys.modules["tracerlib"] = _tracerlib
 
 DEFAULT_AIRR_CELL_ATTRIBUTES = "is_cell"
+
+#: Deprecation of the `include_fields` argument, shared by all `read_*` functions that used to support it.
+_deprecation_include_fields = Deprecation("0.13.0", "Has no effect. All fields are always imported.")
 
 
 def _cdr3_from_junction(junction_aa, junction_nt):
@@ -203,6 +207,7 @@ def _read_10x_vdj_csv(
 
 
 @_doc_params(doc_working_model=doc_working_model)
+@deprecated_arg("include_fields", _deprecation_include_fields)
 def read_10x_vdj(path: str | Path, filtered: bool = True, include_fields: Any = None, **kwargs) -> AnnData:
     """\
     Read :term:`AIRR` data from 10x Genomics cell-ranger output.
@@ -226,7 +231,7 @@ def read_10x_vdj(path: str | Path, filtered: bool = True, include_fields: Any = 
         If using `filtered_contig_annotations.csv` already, this option
         is futile.
     include_fields
-        Deprecated. Does not have any effect as of v0.13.
+        Does not have any effect. All fields are always imported.
     **kwargs
         are passed to :func:`~scirpy.io.from_airr_cells`.
 
@@ -355,6 +360,11 @@ def read_tracer(path: str | Path, **kwargs) -> AnnData:
     doc_airr_fields=doc_airr_fields,
     cell_attributes=f"""`({",".join([f'"{x}"' for x in DEFAULT_AIRR_CELL_ATTRIBUTES])})`""",
 )
+@deprecated_arg(
+    "use_umi_count_col",
+    Deprecation("0.16.0", "Has no effect. `umi_count` now always takes precedence over `duplicate_count`."),
+)
+@deprecated_arg("include_fields", _deprecation_include_fields)
 def read_airr(
     path: str | Sequence[str] | Path | Sequence[Path] | pd.DataFrame | Sequence[pd.DataFrame],
     use_umi_count_col: None = None,  # deprecated, kept for backwards-compatibility
@@ -378,7 +388,7 @@ def read_airr(
         as a List, e.g. `["path/to/tcr_alpha.tsv", "path/to/tcr_beta.tsv"]`.
         Alternatively, this can be a pandas data frame.
     use_umi_count_col
-        Deprecated, has no effect as of v0.16. Since v1.4 of the AIRR standard, `umi_count`
+        Has no effect. Since v1.4 of the AIRR standard, `umi_count`
         is an official field in the Rearrangement schema and preferred over `duplicate_count`.
         `umi_count` now always takes precedence over `duplicate_count`.
     infer_locus
@@ -388,7 +398,7 @@ def read_airr(
         than a chain. The values must be identical over all records belonging to a
         cell. This defaults to {cell_attributes}.
     include_fields
-        Deprecated. Does not have any effect as of v0.13.
+        Does not have any effect. All fields are always imported.
     **kwargs
         are passed to :func:`~scirpy.io.from_airr_cells`.
 

--- a/src/scirpy/ir_dist/__init__.py
+++ b/src/scirpy/ir_dist/__init__.py
@@ -6,17 +6,15 @@ from typing import Literal
 import numpy as np
 from scanpy import logging
 from scipy.sparse import csr_matrix
+from scverse_misc import Deprecation, deprecated
 
 from scirpy.get import airr as get_airr
-from scirpy.util import DataHandler, _doc_params, _is_na, deprecated
+from scirpy.util import DataHandler, _doc_params, _is_na
 
 from . import metrics
 
 
-@deprecated(
-    "Due to added BCR support, this function has been renamed "
-    "to `sequence_dist`. The old version will be removed in a future release. "
-)
+@deprecated(Deprecation("0.5.0", "Due to added BCR support, this function has been renamed to `sequence_dist`."))
 def tcr_dist(*args, **kwargs):
     return sequence_dist(*args, **kwargs)
 

--- a/src/scirpy/ir_dist/metrics.py
+++ b/src/scirpy/ir_dist/metrics.py
@@ -1,6 +1,5 @@
 import abc
 import itertools
-import warnings
 from collections.abc import Sequence
 from typing import Literal
 
@@ -13,8 +12,14 @@ import scipy.spatial
 from Levenshtein import distance as levenshtein_dist
 from scanpy import logging
 from scipy.sparse import coo_matrix, csr_matrix
+from scverse_misc import Deprecation, deprecated, deprecated_arg
 
-from scirpy.util import _doc_params, _get_usable_cpus, _parallelize_with_joblib, deprecated
+from scirpy.util import _doc_params, _get_usable_cpus, _parallelize_with_joblib
+
+#: Deprecation of the object-level `block_size` parameter, shared by all `ParallelDistanceCalculator`s.
+_deprecation_block_size = Deprecation(
+    "0.15.0", "The block size is now set in the `calc_dist_mat` function instead of the object level."
+)
 
 _doc_params_parallel_distance_calculator = """\
 n_jobs
@@ -23,7 +28,7 @@ n_jobs
     Via the :class:`joblib.parallel_config` context manager, another backend (e.g. `dask`)
     can be selected.
 block_size
-    Deprecated. This is now set in `calc_dist_mat`.
+    Deprecated since v0.15.0. This is now set in `calc_dist_mat` and ignored here.
 """
 
 
@@ -112,6 +117,7 @@ class ParallelDistanceCalculator(DistanceCalculator):
     {params}
     """
 
+    @deprecated_arg("block_size", _deprecation_block_size)
     def __init__(
         self,
         cutoff: int,
@@ -121,11 +127,6 @@ class ParallelDistanceCalculator(DistanceCalculator):
     ):
         super().__init__(cutoff)
         self.n_jobs = n_jobs
-        if block_size is not None:
-            warnings.warn(
-                "The `block_size` parameter is now set in the `calc_dist_mat` function instead of the object level. It is ignored here.",
-                category=FutureWarning,
-            )
 
     @abc.abstractmethod
     def _compute_block(
@@ -1529,6 +1530,12 @@ class TCRdistDistanceCalculator(_MetricDistanceCalculator):
     _metric_mat = _tcrdist_mat
 
 
+@deprecated(
+    Deprecation(
+        "0.15.0",
+        "`FastAlignmentDistanceCalculator` achieves (depending on the settings) identical results at a higher speed.",
+    )
+)
 @_doc_params(params=_doc_params_parallel_distance_calculator)
 class AlignmentDistanceCalculator(ParallelDistanceCalculator):
     """\
@@ -1571,12 +1578,7 @@ class AlignmentDistanceCalculator(ParallelDistanceCalculator):
         Gap extend penatly
     """
 
-    @deprecated(
-        """\
-        FastAlignmentDistanceCalculator achieves (depending on the settings) identical results
-        at a higher speed.
-        """
-    )
+    @deprecated_arg("block_size", _deprecation_block_size)
     def __init__(
         self,
         cutoff: int = 10,
@@ -1587,7 +1589,7 @@ class AlignmentDistanceCalculator(ParallelDistanceCalculator):
         gap_open: int = 11,
         gap_extend: int = 11,
     ):
-        super().__init__(cutoff, n_jobs=n_jobs, block_size=block_size)
+        super().__init__(cutoff, n_jobs=n_jobs)
         self.subst_mat = subst_mat
         self.gap_open = gap_open
         self.gap_extend = gap_extend
@@ -1725,6 +1727,7 @@ class FastAlignmentDistanceCalculator(ParallelDistanceCalculator):
         Estimate of the average mismatch penalty
     """
 
+    @deprecated_arg("block_size", _deprecation_block_size)
     def __init__(
         self,
         cutoff: int = 10,
@@ -1736,7 +1739,7 @@ class FastAlignmentDistanceCalculator(ParallelDistanceCalculator):
         gap_extend: int = 11,
         estimated_penalty: float = None,
     ):
-        super().__init__(cutoff, n_jobs=n_jobs, block_size=block_size)
+        super().__init__(cutoff, n_jobs=n_jobs)
         self.subst_mat = subst_mat
         self.gap_open = gap_open
         self.gap_extend = gap_extend

--- a/src/scirpy/pl/_clonal_expansion.py
+++ b/src/scirpy/pl/_clonal_expansion.py
@@ -1,13 +1,17 @@
 from collections.abc import Sequence
 from typing import Literal
 
+from scverse_misc import deprecated_arg
+
 from scirpy import tl
+from scirpy.tl._clonal_expansion import _breakpoints_from_clip_at, _deprecation_clip_at
 from scirpy.util import DataHandler
 
 from . import base
 
 
 @DataHandler.inject_param_docs()
+@deprecated_arg("clip_at", _deprecation_clip_at)
 def clonal_expansion(
     adata: DataHandler.TYPE,
     groupby: str,
@@ -74,6 +78,8 @@ def clonal_expansion(
         Additional arguments passed to :func:`scirpy.pl.base.bar`
     """
     params = DataHandler(adata, airr_mod)
+    if clip_at is not None:
+        breakpoints = _breakpoints_from_clip_at(clip_at)
     plot_df = tl.summarize_clonal_expansion(
         params,
         groupby,
@@ -82,7 +88,6 @@ def clonal_expansion(
         normalize=normalize,
         expanded_in=expanded_in,
         breakpoints=breakpoints,
-        clip_at=clip_at,
     )
     if not show_nonexpanded:
         plot_df.drop("<= 1", axis="columns", inplace=True)

--- a/src/scirpy/tests/test_deprecations.py
+++ b/src/scirpy/tests/test_deprecations.py
@@ -1,0 +1,83 @@
+"""Tests for deprecated functions and function arguments.
+
+Deprecations are declared using the decorators from :mod:`scverse_misc`. The tests here make sure
+that a `FutureWarning` is raised when (and only when) deprecated functionality is used, and that the
+deprecated functionality still behaves as documented.
+"""
+
+import warnings
+
+import pandas.testing as pdt
+import pytest
+
+import scirpy as ir
+from scirpy.ir_dist.metrics import (
+    AlignmentDistanceCalculator,
+    FastAlignmentDistanceCalculator,
+    LevenshteinDistanceCalculator,
+)
+
+from . import TESTDATA
+
+
+def test_tcr_dist_deprecated():
+    with pytest.warns(FutureWarning, match="renamed to `sequence_dist`"):
+        actual = ir.ir_dist.tcr_dist(["AAA", "AAB"], metric="identity", cutoff=0)
+    expected = ir.ir_dist.sequence_dist(["AAA", "AAB"], metric="identity", cutoff=0)
+    assert (actual != expected).nnz == 0
+
+
+def test_block_size_deprecated():
+    """The object-level `block_size` argument is ignored since v0.15.0"""
+    with pytest.warns(FutureWarning, match="argument block_size is deprecated"):
+        LevenshteinDistanceCalculator(2, block_size=50)
+    with pytest.warns(FutureWarning, match="argument block_size is deprecated"):
+        FastAlignmentDistanceCalculator(block_size=50)
+
+
+def _assert_no_deprecation_warning(func, arg: str, *args, **kwargs):
+    """Assert that calling `func` does not raise a deprecation warning about `arg`"""
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always", FutureWarning)
+        result = func(*args, **kwargs)
+    assert not [w for w in record if arg in str(w.message)]
+    return result
+
+
+@pytest.mark.parametrize("calculator", [LevenshteinDistanceCalculator, FastAlignmentDistanceCalculator])
+def test_no_spurious_block_size_warning(calculator):
+    """No warning must be raised if `block_size` is not specified"""
+    _assert_no_deprecation_warning(calculator, "block_size")
+
+
+def test_alignment_distance_calculator_deprecated():
+    with pytest.warns(FutureWarning, match="FastAlignmentDistanceCalculator"):
+        AlignmentDistanceCalculator()
+
+
+def test_clip_at_deprecated(adata_clonotype):
+    """`clip_at = N` is equivalent to `breakpoints = (1, ..., N - 1)`"""
+    with pytest.warns(FutureWarning, match="argument clip_at is deprecated"):
+        actual = ir.tl.clonal_expansion(adata_clonotype, clip_at=3, inplace=False)
+    expected = ir.tl.clonal_expansion(adata_clonotype, breakpoints=(1, 2), inplace=False)
+    pdt.assert_series_equal(actual, expected)
+
+
+def test_clip_at_deprecated_plotting(adata_clonotype):
+    with pytest.warns(FutureWarning, match="argument clip_at is deprecated"):
+        ir.pl.clonal_expansion(adata_clonotype, groupby="group", clip_at=3)
+
+
+def test_no_spurious_clip_at_warning(adata_clonotype):
+    """`pl.clonal_expansion` must not warn just because it wraps `tl.clonal_expansion`"""
+    _assert_no_deprecation_warning(ir.pl.clonal_expansion, "clip_at", adata_clonotype, groupby="group")
+
+
+def test_include_fields_deprecated():
+    with pytest.warns(FutureWarning, match="argument include_fields is deprecated"):
+        ir.io.read_10x_vdj(TESTDATA / "10x/filtered_contig_annotations.csv", include_fields=None)
+
+
+def test_use_umi_count_col_deprecated():
+    with pytest.warns(FutureWarning, match="argument use_umi_count_col is deprecated"):
+        ir.io.read_airr(TESTDATA / "airr/rearrangement_tra.tsv", use_umi_count_col=True)

--- a/src/scirpy/tests/test_io.py
+++ b/src/scirpy/tests/test_io.py
@@ -39,7 +39,7 @@ def _read_anndata_from_10x_sample(path):
     fixtures. Therefore, we use the lru_cache instead.
     """
     print(f"Reading 10x file: {path}")
-    anndata = read_10x_vdj(path, include_fields=None)
+    anndata = read_10x_vdj(path)
     return anndata
 
 
@@ -230,7 +230,7 @@ def test_airr_roundtrip_conversion(anndata_from_10x_sample, tmp_path):
     anndata = anndata_from_10x_sample
     tmp_file = tmp_path / "test.airr.tsv"
     write_airr(anndata, tmp_file)
-    anndata2 = read_airr(tmp_file, include_fields=None)
+    anndata2 = read_airr(tmp_file)
     _normalize_df_types(anndata.obs)
     _normalize_df_types(anndata2.obs)
     pdt.assert_frame_equal(anndata.obs, anndata2.obs, check_dtype=False, check_categorical=False)
@@ -355,10 +355,7 @@ def test_read_10x_csv():
 )
 def test_read_10x_cr6(testfile):
     """Test additional cols from CR6 outputs: fwr{1,2,3,4}{,_nt} and cdr{1,2}{,_nt}"""
-    anndata = read_10x_vdj(
-        testfile,
-        include_fields=None,
-    )
+    anndata = read_10x_vdj(testfile)
     obs = anndata.obs.join(
         ir.get.airr(
             anndata,
@@ -424,7 +421,7 @@ def test_read_10x_cr6(testfile):
 
 @pytest.mark.conda
 def test_read_10x():
-    anndata = read_10x_vdj(TESTDATA / "10x/all_contig_annotations.json", include_fields=None)
+    anndata = read_10x_vdj(TESTDATA / "10x/all_contig_annotations.json")
     obs = anndata.obs.join(
         ir.get.airr(
             anndata,

--- a/src/scirpy/tests/test_workflow.py
+++ b/src/scirpy/tests/test_workflow.py
@@ -63,7 +63,7 @@ def test_workflow(adata_path, save_intermediates, upgrade_schema, obs_expected, 
         adata = sc.read_h5ad(adata_path)
         ir.io.upgrade_schema(adata)
     else:
-        adata = ir.io.read_10x_vdj(adata_path, include_fields=None)
+        adata = ir.io.read_10x_vdj(adata_path)
 
     adata_obs_expected = pd.read_pickle(_pd_versioned_pkl(obs_expected))
 

--- a/src/scirpy/tl/_clonal_expansion.py
+++ b/src/scirpy/tl/_clonal_expansion.py
@@ -1,11 +1,19 @@
-import warnings
 from collections.abc import Sequence
 from typing import Literal
 
 import numpy as np
 import pandas as pd
+from scverse_misc import Deprecation, deprecated_arg
 
 from scirpy.util import DataHandler, _is_na, _normalize_counts
+
+#: Deprecation of the `clip_at` argument, shared by `tl.clonal_expansion` and `pl.clonal_expansion`.
+_deprecation_clip_at = Deprecation("0.14.0", "Use `breakpoints` instead.")
+
+
+def _breakpoints_from_clip_at(clip_at: int) -> list[int]:
+    """Convert the deprecated `clip_at` argument into a list of `breakpoints`."""
+    return list(range(1, clip_at))
 
 
 def _clip_and_count(
@@ -59,6 +67,7 @@ def _clip_and_count(
 
 
 @DataHandler.inject_param_docs()
+@deprecated_arg("clip_at", _deprecation_clip_at)
 def clonal_expansion(
     adata: DataHandler.TYPE,
     *,
@@ -107,8 +116,7 @@ def clonal_expansion(
     a Series with the clipped count per cell.
     """
     if clip_at is not None:
-        breakpoints = list(range(1, clip_at))
-        warnings.warn("The argument `clip_at` is deprecated. Please use `brekpoints` instead.", category=FutureWarning)
+        breakpoints = _breakpoints_from_clip_at(clip_at)
     return _clip_and_count(
         adata,
         target_col,

--- a/src/scirpy/util/__init__.py
+++ b/src/scirpy/util/__init__.py
@@ -1,6 +1,5 @@
 import json
 import os
-import warnings
 from collections.abc import Callable, Sequence
 from textwrap import dedent
 from typing import Any, Union, cast, overload
@@ -461,25 +460,6 @@ def _read_to_str(path):
     """Read a file into a string"""
     with open(path) as f:
         return f.read()
-
-
-def deprecated(message):
-    """Decorator to mark a function as deprecated"""
-    message = dedent(message)
-
-    def deprecated_decorator(func):
-        def deprecated_func(*args, **kwargs):
-            warnings.warn(
-                f"{func.__name__} is a deprecated function and will be removed in a "
-                f"future version of scirpy. {message}",
-                category=FutureWarning,
-                stacklevel=2,
-            )
-            return func(*args, **kwargs)
-
-        return deprecated_func
-
-    return deprecated_decorator
 
 
 def _translate_dna_to_protein(dna_seq: str):


### PR DESCRIPTION
Replace the home-grown `scirpy.util.deprecated` decorator and the ad-hoc
`warnings.warn` calls with the `deprecated` and `deprecated_arg` decorators
from `scverse-misc`, which also add a deprecation notice to the API docs.

`scverse-misc` is added as a hard dependency (no extras required; the
`[sphinx]` extra remains in the `doc` dependency group).

Deprecated functions:
  * `ir_dist.tcr_dist` (0.5.0)
  * `ir_dist.metrics.AlignmentDistanceCalculator` (0.15.0). The decorator moves
    from `__init__` to the class so the notice appears in the class docs.

Deprecated arguments:
  * `clip_at` of `tl.clonal_expansion` and `pl.clonal_expansion` (0.14.0)
  * `block_size` of the `ParallelDistanceCalculator`s (0.15.0)
  * `include_fields` (0.13.0) and `use_umi_count_col` (0.16.0) of the
    `io.read_*` functions
  * `cached`/`cache_path` of `datasets.vdjdb` and `datasets.iedb` (0.24.0)

The latter two groups previously did not emit any warning at all and now
consistently raise a `FutureWarning`.

Since `deprecated_arg` warns whenever the deprecated argument is passed
(irrespective of its value), internal calls must not forward it:
`pl.clonal_expansion` now converts `clip_at` into `breakpoints` itself instead
of passing it on to `tl.clonal_expansion`, and the alignment distance
calculators no longer forward the ignored `block_size` to their base class.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Closes #704

- [x] CHANGELOG.md updated
- [x] Tests added (For bug fixes or new features)
- [ ] Tutorial updated (if necessary)
