### PR TITLE
Clean up usage of _is_na, _is_true and _is_false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to [Semantic Versioning][].
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html
 
+## Unreleased
+
+### Fixes
+
+  - `AirrCell.add_chain` now casts values to the type declared in the AIRR rearrangement schema. Previously, building
+    `AirrCell` objects from data that spelled out booleans or numbers as strings (e.g. `productive="True"`) resulted in
+    an `adata.obsm["airr"]` array with union types that `pp.index_chains` could not process
+    ([#380](https://github.com/scverse/scirpy/issues/380)).
+  - `pl.vdj_usage` again shows cells without a gene call as a separate `none` segment instead of silently omitting them.
+
+### Chore
+
+  - Remove the `_is_na`/`_is_true`/`_is_false` checks outside of the `scirpy.io` module. Since scirpy guarantees the
+    data types in `adata.obsm["airr"]`, missing values can be detected with `pandas.isnull`, which is faster and easier
+    to read ([#380](https://github.com/scverse/scirpy/issues/380)).
+
 ## v0.25.0
 
 ### Fixes

--- a/src/scirpy/io/_datastructures.py
+++ b/src/scirpy/io/_datastructures.py
@@ -12,7 +12,7 @@ import scanpy
 
 from scirpy.util import _is_na2
 
-from ._util import get_rearrangement_schema
+from ._util import _sanitize_airr_value, get_rearrangement_schema
 
 
 class AirrCell(MutableMapping):
@@ -121,11 +121,14 @@ class AirrCell(MutableMapping):
 
         A chain is a dictionary following
         the `AIRR Rearrangement Schema <https://docs.airr-community.org/en/latest/datarep/rearrangements.html#productive>`__.
+
+        Values are sanitized before they are stored: text representations of missing values (e.g. `"nan"`, `"None"`)
+        become `None` and strings are cast to the type declared in the AIRR schema (e.g. `"True"` -> `True`).
         """
         # ensure consistent ordering
         chain = dict(sorted(chain.items()))
-        # sanitize NA values
-        chain = {k: None if _is_na2(v) else v for k, v in chain.items()}
+        # sanitize NA values and cast strings to the type declared in the AIRR schema
+        chain = {k: _sanitize_airr_value(k, v) for k, v in chain.items()}
 
         get_rearrangement_schema().validate_header(chain.keys())
         get_rearrangement_schema().validate_row(chain)

--- a/src/scirpy/io/_util.py
+++ b/src/scirpy/io/_util.py
@@ -1,9 +1,12 @@
 import csv
 import os
 from collections import Counter
+from typing import Any
 
 import pandas as pd
 from scanpy import logging
+
+from scirpy.util import _is_na2
 
 doc_working_model = """\
 
@@ -40,6 +43,43 @@ def get_rearrangement_schema():
     from airr import RearrangementSchema
 
     return RearrangementSchema
+
+
+def _sanitize_airr_value(field: str, value: Any) -> Any:
+    """Sanitize a single value of an AIRR rearrangement record.
+
+    Text representations of missing values (e.g. `"nan"`, `"None"`, `""`) are converted to `None` and
+    values of typed AIRR fields (e.g. `productive`, `umi_count`) that are still strings are cast to
+    their native Python type (e.g. `"True"` -> `True`, `"3"` -> `3`).
+
+    This is the only place where scirpy deals with such text representations. Everything downstream
+    can rely on `adata.obsm["airr"]` having consistent data types.
+
+    Parameters
+    ----------
+    field
+        Name of the AIRR rearrangement field. Fields that are not part of the AIRR rearrangement
+        schema are only checked for missing values, since their type is unknown.
+    value
+        The value to sanitize
+
+    Returns
+    -------
+    The sanitized value.
+    """
+    if _is_na2(value):
+        return None
+    if not isinstance(value, str):
+        # only strings need to be cast -- everything else is already a native Python (or numpy) type.
+        return value
+    schema = get_rearrangement_schema()
+    converter = {"boolean": schema.to_bool, "integer": schema.to_int, "number": schema.to_float}.get(schema.type(field))
+    if converter is None:
+        # the field is not part of the schema, or is of a type that doesn't need casting (e.g. `string`)
+        return value
+    # `validate=True` raises a `ValidationError` for values that cannot be cast. This is consistent
+    # with `validate_row`, which is called on the full record in `AirrCell.add_chain`.
+    return converter(value, validate=True)
 
 
 class _IOLogger:

--- a/src/scirpy/ir_dist/__init__.py
+++ b/src/scirpy/ir_dist/__init__.py
@@ -4,11 +4,12 @@ from collections.abc import Sequence
 from typing import Literal
 
 import numpy as np
+import pandas as pd
 from scanpy import logging
 from scipy.sparse import csr_matrix
 
 from scirpy.get import airr as get_airr
-from scirpy.util import DataHandler, _doc_params, _is_na, deprecated
+from scirpy.util import DataHandler, _doc_params, deprecated
 
 from . import metrics
 
@@ -238,10 +239,10 @@ def _ir_dist(
     # get all unique seqs for VJ and VDJ
     def _get_unique_seqs(tmp_adata, chain_type):
         """Get all unique sequences for a chain type"""
-        tmp_seqs = np.concatenate(
-            [get_airr(tmp_adata, key, f"{chain_type}_{chain_id}").values for chain_id in ["1", "2"]]  # type: ignore
+        tmp_seqs = pd.concat(
+            [get_airr(tmp_adata, key, f"{chain_type}_{chain_id}") for chain_id in ["1", "2"]]  # type: ignore
         )
-        return np.unique([x.upper() for x in tmp_seqs[~_is_na(tmp_seqs)]])
+        return np.unique(tmp_seqs.dropna().str.upper().to_numpy(dtype=str))
 
     for i, tmp_params in enumerate([params, params_ref]):
         if tmp_params is not None:

--- a/src/scirpy/pl/_vdj_usage.py
+++ b/src/scirpy/pl/_vdj_usage.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from scirpy.get import airr as get_airr
 from scirpy.io import AirrCell
-from scirpy.util import DataHandler, _is_na, _normalize_counts
+from scirpy.util import DataHandler, _normalize_counts
 
 from .styling import _init_ax
 
@@ -111,7 +111,9 @@ def vdj_usage(
     )
     for col in df.columns:
         if col.startswith("VJ") or col.startswith("VDJ"):
-            df[col] = df[col].astype(str)
+            # cells without a gene call get their own "none" segment. Keeping them as NaN would
+            # silently drop them from the `groupby` calls below.
+            df[col] = df[col].astype(str).fillna("none")
 
     # Init figure
     default_figargs = {"figsize": (7, 4)}
@@ -163,8 +165,6 @@ def vdj_usage(
 
         # Draw gene segments
         for i, (segment_size, gene) in list(enumerate(zip(segment_sizes, genes, strict=False)))[:max_segments][::-1]:
-            if _is_na(gene):
-                gene = "none"
             gene_tops[col_name][gene] = bottom + segment_size
             if draw_bars:
                 bar_colors = ax.bar(
@@ -227,18 +227,14 @@ def vdj_usage(
                 ribbon_color = None
             else:
                 try:
-                    tmp_gene = ribbon[target_pair[0]]
                     tmp_col = target_pair[0]
-                    tmp_gene = "none" if _is_na(tmp_gene) else tmp_gene
-                    ribbon_color = gene_colors[tmp_col][tmp_gene]
+                    ribbon_color = gene_colors[tmp_col][ribbon[tmp_col]]
                 except KeyError:
                     # Don't draw ribbon if the source gene is not drawn.
                     continue
 
             for col_name in target_pair:
                 gene = ribbon[col_name]
-                if _is_na(gene):
-                    gene = "none"
                 if gene not in tmp_gene_tops[col_name]:
                     gene = "other"
                 top = tmp_gene_tops[col_name][gene]

--- a/src/scirpy/tests/conftest.py
+++ b/src/scirpy/tests/conftest.py
@@ -558,7 +558,7 @@ def adata_diversity(request):
             ["cell1", "A", "ct1"],
             ["cell2", "A", "ct1"],
             ["cell3", "A", "ct1"],
-            ["cell3.1", "A", "NaN"],
+            ["cell3.1", "A", None],
             ["cell4", "B", "ct1"],
             ["cell5", "B", "ct2"],
             ["cell6", "B", "ct3"],

--- a/src/scirpy/tests/test_io.py
+++ b/src/scirpy/tests/test_io.py
@@ -1,6 +1,8 @@
 from functools import lru_cache
 
+import awkward as ak
 import numpy as np
+import numpy.testing as npt
 import pandas as pd
 import pandas.testing as pdt
 import pytest
@@ -96,6 +98,135 @@ def test_airr_cell():
     assert ac["fieldB"] == "b"
     assert "fieldB" not in ac.chains[0]
     assert ac.chains[0]["fieldC"] == "c"
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        # text representations of missing values
+        pytest.param(None, None, id="None"),
+        pytest.param(np.nan, None, id="np.nan"),
+        pytest.param("", None, id="empty_str"),
+        pytest.param("nan", None, id="'nan'"),
+        pytest.param("NaN", None, id="'NaN'"),
+        pytest.param("None", None, id="'None'"),
+        pytest.param("N/A", None, id="'N/A'"),
+        # actual values are passed through unchanged
+        pytest.param("CASSYGGYF", "CASSYGGYF", id="value"),
+    ],
+)
+def test_airr_cell_sanitize_na(value, expected):
+    """Text representations of NA are converted to `None` when a chain is added to an AirrCell"""
+    ac = AirrCell("cell1")
+    chain = AirrCell.empty_chain_dict()
+    chain["junction_aa"] = value
+    ac.add_chain(chain)
+    assert ac.chains[0]["junction_aa"] == expected
+
+
+@pytest.mark.parametrize(
+    "field,value,expected",
+    [
+        # `productive` is declared as `boolean` in the AIRR rearrangement schema
+        pytest.param("productive", "True", True, id="productive-'True'"),
+        pytest.param("productive", "true", True, id="productive-'true'"),
+        pytest.param("productive", "TRUE", True, id="productive-'TRUE'"),
+        pytest.param("productive", "T", True, id="productive-'T'"),
+        pytest.param("productive", "1", True, id="productive-'1'"),
+        pytest.param("productive", "False", False, id="productive-'False'"),
+        pytest.param("productive", "false", False, id="productive-'false'"),
+        pytest.param("productive", "F", False, id="productive-'F'"),
+        pytest.param("productive", "0", False, id="productive-'0'"),
+        pytest.param("productive", True, True, id="productive-True"),
+        pytest.param("productive", False, False, id="productive-False"),
+        pytest.param("productive", "nan", None, id="productive-'nan'"),
+        # `umi_count` is declared as `integer`
+        pytest.param("umi_count", "42", 42, id="umi_count-'42'"),
+        pytest.param("umi_count", 42, 42, id="umi_count-42"),
+        pytest.param("umi_count", "None", None, id="umi_count-'None'"),
+        # `duplicate_count` is declared as `integer`, too
+        pytest.param("duplicate_count", "3", 3, id="duplicate_count-'3'"),
+        # `v_support` is declared as `number`
+        pytest.param("v_support", "0.5", 0.5, id="v_support-'0.5'"),
+        pytest.param("v_support", 0.5, 0.5, id="v_support-0.5"),
+        # `junction_aa` is declared as `string` -- must not be converted
+        pytest.param("junction_aa", "0", "0", id="junction_aa-'0'"),
+        # fields that are not part of the AIRR schema are left alone
+        pytest.param("high_confidence", "True", "True", id="high_confidence-'True'"),
+    ],
+)
+def test_airr_cell_sanitize_types(field, value, expected):
+    """Strings are cast to the type declared in the AIRR rearrangement schema.
+
+    This is what allows all downstream functions to rely on the data types in `adata.obsm["airr"]`
+    (see https://github.com/scverse/scirpy/issues/380).
+    """
+    ac = AirrCell("cell1")
+    chain = AirrCell.empty_chain_dict()
+    chain[field] = value
+    ac.add_chain(chain)
+    tmp_value = ac.chains[0][field]
+    assert tmp_value == expected or (tmp_value is None and expected is None)
+    if expected is not None:
+        assert isinstance(tmp_value, type(expected))
+
+
+@pytest.mark.parametrize("field,value", [("productive", "yes"), ("umi_count", "a lot"), ("v_support", "high")])
+def test_airr_cell_sanitize_types_invalid(field, value):
+    """Values that cannot be cast to the type declared in the AIRR schema raise an error"""
+    from airr import ValidationError
+
+    ac = AirrCell("cell1")
+    chain = AirrCell.empty_chain_dict()
+    chain[field] = value
+    with pytest.raises(ValidationError):
+        ac.add_chain(chain)
+
+
+def test_from_airr_cells_string_representations():
+    """AirrCells built from data that uses string representations of NA/True/False result in an
+    AnnData object with consistent dtypes that can be processed by the rest of scirpy.
+
+    See https://github.com/scverse/scirpy/issues/380.
+    """
+
+    def _make_cell(cell_id, **kwargs):
+        tmp_cell = AirrCell(cell_id)
+        chain = AirrCell.empty_chain_dict()
+        chain.update(kwargs)
+        tmp_cell.add_chain(chain)
+        return tmp_cell
+
+    cells = [
+        _make_cell("cell1", locus="TRA", junction_aa="CAT", productive="True", umi_count="3"),
+        _make_cell("cell2", locus="TRB", junction_aa="CAS", productive=True, umi_count=5),
+        # non-productive -> filtered out by `index_chains`
+        _make_cell("cell3", locus="TRB", junction_aa="CAR", productive="False", umi_count="2"),
+        # no junction_aa -> filtered out by `index_chains`
+        _make_cell("cell4", locus="TRB", junction_aa="nan", productive="true", umi_count="2"),
+    ]
+    adata = from_airr_cells(cells)
+
+    # no union types in the awkward array, i.e. the same field has the same type for all cells
+    airr = adata.obsm["airr"]
+    assert "union" not in str(airr.type)
+    npt.assert_equal(np.asarray(ak.to_list(ak.flatten(airr["productive"]))), np.array([True, True, False, True]))
+    npt.assert_equal(np.asarray(ak.to_list(ak.flatten(airr["umi_count"]))), np.array([3, 5, 2, 2]))
+
+    # only the productive chains with a junction_aa sequence are indexed
+    ir.pp.index_chains(adata)
+    pdt.assert_series_equal(
+        ir.get.airr(adata, "junction_aa", "VJ_1"),
+        pd.Series(["CAT", None, None, None], index=adata.obs_names),
+        check_dtype=False,
+        check_names=False,
+    )
+    pdt.assert_series_equal(
+        ir.get.airr(adata, "junction_aa", "VDJ_1"),
+        pd.Series([None, "CAS", None, None], index=adata.obs_names),
+        check_dtype=False,
+        check_names=False,
+    )
 
 
 def test_airr_cell_empty():

--- a/src/scirpy/tests/test_plotting.py
+++ b/src/scirpy/tests/test_plotting.py
@@ -88,6 +88,16 @@ def test_vdj_usage(adata_vdj, full_combination):
     assert isinstance(p, plt.Axes)
 
 
+def test_vdj_usage_missing_genes(adata_vdj):
+    """Cells without a gene call are shown as a separate `none` segment rather than being dropped.
+
+    `adata_vdj` has 6 cells without a `VDJ_1_d_call`.
+    """
+    p = pl.vdj_usage(adata_vdj, vdj_cols=("VDJ_1_d_call",), normalize_to=False)
+    # one label per segment. Segments are labelled with the gene name, stripped of the locus prefix.
+    assert {t.get_text() for t in p.texts} == {"none", "D1", "D2"}
+
+
 @pytest.mark.extra
 @pytest.mark.parametrize("matrix_type", ["array", "csr", "csc"])
 @pytest.mark.parametrize("use_raw", [False, None])

--- a/src/scirpy/tests/test_tools.py
+++ b/src/scirpy/tests/test_tools.py
@@ -291,7 +291,7 @@ def test_group_abundance():
             ["cell1", "A", "ct1"],
             ["cell2", "A", "ct1"],
             ["cell3", "A", "ct1"],
-            ["cell4", "A", "NaN"],
+            ["cell4", "A", None],
             ["cell5", "B", "ct1"],
             ["cell6", "B", "ct2"],
         ],

--- a/src/scirpy/tl/_chain_qc.py
+++ b/src/scirpy/tl/_chain_qc.py
@@ -7,7 +7,7 @@ import pandas as pd
 from scanpy import logging
 
 from scirpy import get
-from scirpy.util import DataHandler, _is_na
+from scirpy.util import DataHandler
 
 
 @DataHandler.inject_param_docs()
@@ -176,10 +176,10 @@ def _chain_pairing(
 
     logging.debug("Done initalizing")
 
-    mask_has_vj1 = ~_is_na(get.airr(params, "junction_aa", "VJ_1").values)
-    mask_has_vdj1 = ~_is_na(get.airr(params, "junction_aa", "VDJ_1").values)
-    mask_has_vj2 = ~_is_na(get.airr(params, "junction_aa", "VJ_2").values)
-    mask_has_vdj2 = ~_is_na(get.airr(params, "junction_aa", "VDJ_2").values)
+    mask_has_vj1 = get.airr(params, "junction_aa", "VJ_1").notnull().values
+    mask_has_vdj1 = get.airr(params, "junction_aa", "VDJ_1").notnull().values
+    mask_has_vj2 = get.airr(params, "junction_aa", "VJ_2").notnull().values
+    mask_has_vdj2 = get.airr(params, "junction_aa", "VDJ_2").notnull().values
 
     logging.debug("Done with masks")
 

--- a/src/scirpy/tl/_clonal_expansion.py
+++ b/src/scirpy/tl/_clonal_expansion.py
@@ -5,7 +5,7 @@ from typing import Literal
 import numpy as np
 import pandas as pd
 
-from scirpy.util import DataHandler, _is_na, _normalize_counts
+from scirpy.util import DataHandler, _normalize_counts
 
 
 def _clip_and_count(
@@ -48,7 +48,8 @@ def _clip_and_count(
         .assign(tmp_count=lambda X: pd.Categorical(_get_interval(X["tmp_count"].values), categories=categories))
     )
     clipped_count = obs.merge(clonotype_counts, how="left", on=groupby_cols)["tmp_count"]
-    clipped_count[_is_na(obs[target_col])] = "nan"
+    # `merge` resets the index, therefore we need to mask by position
+    clipped_count[obs[target_col].isnull().to_numpy()] = "nan"
     clipped_count.index = obs.index
 
     if inplace:
@@ -170,7 +171,7 @@ def summarize_clonal_expansion(
     obs[tmp_col] = expansion
 
     # filter NA values
-    obs = obs.loc[~_is_na(obs[target_col]), :]
+    obs = obs.loc[obs[target_col].notnull(), :]
 
     if summarize_by == "clone_id":
         obs.drop_duplicates(inplace=True)

--- a/src/scirpy/tl/_clonotype_modularity.py
+++ b/src/scirpy/tl/_clonotype_modularity.py
@@ -8,7 +8,7 @@ from mudata import MuData
 from scanpy import logging
 from statsmodels.stats.multitest import fdrcorrection
 
-from scirpy.util import DataHandler, _is_na, tqdm
+from scirpy.util import DataHandler, tqdm
 from scirpy.util._negative_binomial import fit_nbinom
 from scirpy.util.graph import _get_igraph_from_adjacency
 
@@ -107,7 +107,7 @@ def clonotype_modularity(
         n_permutations = 1000 if permutation_test == "approx" else 10000
 
     clonotype_per_cell = params.get_obs(target_col)
-    cells_with_valid_clonotype = clonotype_per_cell[~_is_na(clonotype_per_cell.values)].index
+    cells_with_valid_clonotype = clonotype_per_cell.dropna().index
     data_subset = params.data[cells_with_valid_clonotype.values, :]
     try:
         connectivities = data_subset.obsp[connectivity_key]

--- a/src/scirpy/tl/_diversity.py
+++ b/src/scirpy/tl/_diversity.py
@@ -4,7 +4,7 @@ from typing import cast
 import numpy as np
 import pandas as pd
 
-from scirpy.util import DataHandler, _is_na
+from scirpy.util import DataHandler
 
 
 def _shannon_entropy(counts: np.ndarray):
@@ -105,7 +105,7 @@ def alpha_diversity(
     """
     params = DataHandler(adata, airr_mod)
     ir_obs = params.get_obs([target_col, groupby])
-    ir_obs = ir_obs.loc[~_is_na(ir_obs[target_col]), :]
+    ir_obs = ir_obs.loc[ir_obs[target_col].notnull(), :]
     clono_counts = ir_obs.groupby([groupby, target_col], observed=True).size().reset_index(name="count")
 
     diversity = {}

--- a/src/scirpy/tl/_group_abundance.py
+++ b/src/scirpy/tl/_group_abundance.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 
 from scirpy.get import _has_ir
-from scirpy.util import DataHandler, _is_na, _normalize_counts
+from scirpy.util import DataHandler, _normalize_counts
 
 
 def _group_abundance(
@@ -17,7 +17,7 @@ def _group_abundance(
     sort: Literal["count", "alphabetical"] | Sequence[str] = "count",
 ) -> pd.DataFrame:
     # remove NA rows
-    na_mask = _is_na(ir_obs[groupby]) | _is_na(ir_obs[target_col])
+    na_mask = ir_obs[groupby].isnull() | ir_obs[target_col].isnull()
     ir_obs = ir_obs.loc[~na_mask, :]
 
     # normalize to fractions

--- a/src/scirpy/tl/_ir_query.py
+++ b/src/scirpy/tl/_ir_query.py
@@ -10,7 +10,7 @@ from scanpy import logging
 
 from scirpy.ir_dist import MetricType, _get_metric_key
 from scirpy.ir_dist._clonotype_neighbors import ClonotypeNeighbors
-from scirpy.util import DataHandler, _is_na, read_cell_indices, tqdm
+from scirpy.util import DataHandler, read_cell_indices, tqdm
 
 from ._clonotypes import _common_doc, _common_doc_parallelism, _doc_clonotype_definition, _validate_parameters
 
@@ -404,10 +404,6 @@ def ir_query_annotate(
         except KeyError:
             raise ValueError("Invalid value for `strategy`.") from None
         df_res = df.groupby("_query_cell_index").aggregate(reduce_fun).reindex(params.adata.obs_names)
-
-    # convert nan-equivalents to real nan values.
-    for col in df_res:
-        df_res.loc[_is_na(df_res[col]), col] = None
 
     if inplace:
         for col in df_res:

--- a/src/scirpy/tl/_repertoire_overlap.py
+++ b/src/scirpy/tl/_repertoire_overlap.py
@@ -5,7 +5,7 @@ import pandas as pd
 from scipy.cluster import hierarchy as sc_hierarchy
 from scipy.spatial import distance as sc_distance
 
-from scirpy.util import DataHandler, _is_na, _normalize_counts
+from scirpy.util import DataHandler, _normalize_counts
 
 
 @DataHandler.inject_param_docs()
@@ -65,7 +65,7 @@ def repertoire_overlap(
         obs[normalize] = params.get_obs(normalize)
 
     # Remove NA rows
-    na_mask = _is_na(obs[groupby]) | _is_na(obs[target_col])
+    na_mask = obs[groupby].isnull() | obs[target_col].isnull()
     df = obs.loc[~na_mask, :].copy()
 
     # Normalize to fractions

--- a/src/scirpy/util/__init__.py
+++ b/src/scirpy/util/__init__.py
@@ -392,43 +392,47 @@ def _is_symmetric(M) -> bool:
 
 def _is_na2(x):
     """Check if an object or string is NaN.
-    The function is vectorized over numpy arrays or pandas Series
-    but also works for single values.
 
-    Pandas Series are converted to numpy arrays.
+    .. warning::
+        This is only meant for sanitizing input data in the :mod:`scirpy.io` module. Within scirpy's
+        :ref:`data structure <data-structure>`, missing values are guaranteed to be `None`/`NaN`, never a
+        text representation thereof. Use :func:`pandas.isnull` there instead.
     """
     return pd.isnull(x) or x in ("NaN", "nan", "None", "N/A", "")
 
 
+#: Vectorized version of :func:`_is_na2`. Same caveats apply.
 _is_na = np.vectorize(_is_na2, otypes=[bool])
 
 
 def _is_true2(x):
-    """Evaluates true for bool(x) unless _is_false(x) evaluates true.
+    """Evaluates true for bool(x) unless _is_false2(x) evaluates true.
     I.e. strings like "false" evaluate as False.
 
-    Everything that evaluates to _is_na(x) evaluates evaluate to False.
+    Everything that evaluates to _is_na2(x) evaluates to False.
 
-    The function is vectorized over numpy arrays or pandas Series
-    but also works for single values.
+    .. warning::
+        This is only meant for sanitizing input data in the :mod:`scirpy.io` module. See :func:`_is_na2`.
     """
     return not _is_false2(x) and not _is_na2(x)
 
 
+#: Vectorized version of :func:`_is_true2`. Same caveats apply.
 _is_true = np.vectorize(_is_true2, otypes=[bool])
 
 
 def _is_false2(x):
     """Evaluates false for bool(False) and str("false")/str("False").
-    The function is vectorized over numpy arrays or pandas Series.
 
-    Everything that is NA as defined in `is_na()` evaluates to False.
+    Everything that is NA as defined in `_is_na2()` evaluates to False.
 
-    but also works for single values.
+    .. warning::
+        This is only meant for sanitizing input data in the :mod:`scirpy.io` module. See :func:`_is_na2`.
     """
     return (x in ("False", "false", "0") or not bool(x)) and not _is_na2(x)
 
 
+#: Vectorized version of :func:`_is_false2`. Same caveats apply.
 _is_false = np.vectorize(lambda x: _is_false2(np.array(x).astype(object)), otypes=[bool])
 
 


### PR DESCRIPTION
Since #356, the data types in `.obsm["airr"]` are guaranteed, so downstream
code no longer needs to guard against string representations of `NaN`,
`True` and `False`. Replace those checks with `pandas.isnull`/`notnull`,
which is both faster and easier to read. The only remaining occurrences are
in `scirpy.io`, where input data is sanitized before it is stored.

To make that guarantee hold for arbitrary input, `AirrCell.add_chain` now
also casts strings to the type declared in the AIRR rearrangement schema.
Previously, building `AirrCell` objects from data that spelled out booleans
or numbers as strings (e.g. `productive="True"`) produced an
`.obsm["airr"]` array with union types that `pp.index_chains` could not
process.

Two follow-ups fell out of this:

* `pl.vdj_usage` relied on `astype(str)` turning missing gene calls into
  the string `"nan"`, which no longer happens with pandas' nullable string
  dtypes. As a result the `none` segment was silently dropped from the
  plot. Missing values are now replaced with `"none"` explicitly.
* Two test fixtures spelled a missing clonotype as the string `"NaN"` in
  `obs`. Those now use `None`.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

Closes #380

- [ ] CHANGELOG.md updated
- [ ] Tests added (For bug fixes or new features)
- [ ] Tutorial updated (if necessary)
